### PR TITLE
sv: merge NST lexicon (820K entries) with existing Swedish data

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ You can search the data online on the [IPA Lookup](https://open-dict-data.github
 
 * [Aspell](http://aspell.net/) for reference wordlists
 * [Folkets lexikon](https://folkets-lexikon.csc.kth.se/folkets/) for Swedish pronunciation data. ([CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/))
+* [NST Pronunciation Lexicon for Swedish](https://www.nb.no/sprakbanken/en/resource-catalogue/oai-nb-no-sbr-22/) (Nordic Language Technology AS / Språkbanken) for expanded Swedish pronunciation data. ([CC0](https://creativecommons.org/publicdomain/zero/1.0/))
 * [Edict](https://www.edrdg.org/jmdict/edict.html) for Japanese pronunciation data ([CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))
 * [_A Learner's Grammar of Jamaican_](https://github.com/opengrammar/jam-learners-grammar) from the [Open Grammar Project](https://github.com/opengrammar) for Jamaican Creole pronunciation data ([CC BY 4.0](https://creativecommons.org/licenses/by/4.0/))
 * [Unihan](https://www.unicode.org/charts/unihan.html) for Chinese character pronunciation data ([Unicode License](https://www.unicode.org/license.html))


### PR DESCRIPTION
## Summary

Expands the Swedish (`sv`) pronunciation dictionary from 21,107 to 819,979 entries by merging in the NST Swedish pronunciation lexicon.

### Source

- **Original NST lexicon** (~927K entries), produced by Nordic Language Technology (NST), available from Språkbanken (National Library of Norway):
  https://www.nb.no/sprakbanken/en/resource-catalogue/oai-nb-no-sbr-22/

### Conversion

A new converter was written to handle the NST SAMPA format (Latin-1 encoded, semicolon-separated, 51 fields; field 0 = orthography, field 11 = concatenated SAMPA):

- Greedy longest-match tokenizer for concatenated SAMPA (no spaces between phonemes in source)
- Tone-2 (`""` prefix in SAMPA) → `²ˈ` before stressed vowel — **664,497 entries** carry the `²` marker
- Tone-1 (`"` prefix) → `ˈ` before stressed vowel
- Secondary stress (`%` prefix) → `ˌ` before stressed vowel
- Monosyllabic words: no stress marker
- Phrase accent (`¤`) and word boundaries (`_`) treated as syllable boundaries
- Multi-word entries: `_` in orthography converted to space

Key SAMPA→IPA mappings: `x\`→`ɧ`, `s'`→`ɕ`, `` s` ``→`ʂ`, `}:`→`ʉː`, `u0`→`ɵ`, retroflex consonants (`` t` d` n` l` ``) → `ʈ ɖ ɳ ɭ`

### Lexicon quality

26.95% of NST entries are manually transcribed base forms; the remaining 73.05% are generated by a morphological inflector from those verified base forms (Kullmann 2016, KTH).

### Merge strategy

- All 21,107 existing ipa-dict `sv.txt` entries are preserved unchanged (priority layer)
- 798,872 new entries added from NST (words not already present)
- Swedish alphabetical sort: `å` (26), `ä` (27), `ö` (28) after `z`